### PR TITLE
add pacman i3blocks

### DIFF
--- a/ansible/vars/pacman.yml
+++ b/ansible/vars/pacman.yml
@@ -102,6 +102,7 @@ pacman:
   gnome:
   i3-wm:
   i3status:
+  i3blocks:
   libreoffice-fresh:
   lxappearance:
   nautilus:


### PR DESCRIPTION
Run `setup.sh` on archlinux. And run` startx`. The following i3-error appears.

> error status_command not found or is missing a library dependency (exit 127)

This happens because i3blocks is not installed.

> .config/i3/config (L183)

```sh
status_command i3blocks
```

